### PR TITLE
Update AmiSSL SDK to current version 5.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The **docker4amigavbcc:latest-base** image contains software that is common on a
 | app               | version               | source
 |-------------------|-----------------------|-----------------------------------|
 | vlink             | 0.17 (26-Feb-2022)    | http://sun.hasenbraten.de/vlink/
-| AmiSSL SDK        | 4.12                  | https://github.com/jens-maus/amissl/releases/download/4.11
+| AmiSSL SDK        | 5.3                   | https://github.com/jens-maus/amissl/releases/tag/5.3
 | FlexCat           | 2.18                  | https://github.com/adtools/flexcat/releases/tag/2.18
 | lha               | 1.14i-ac20220213      | https://github.com/jca02266/lha.git
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -47,7 +47,7 @@ RUN curl -fsSL "http://sun.hasenbraten.de/vlink/release/vlink.tar.gz" -o /tmp/vl
     rm -rf /tmp/*;
 
 # Install AMISSL SDK
-RUN curl -fsSL "https://github.com/jens-maus/amissl/releases/download/4.12/AmiSSL-4.12.lha" -o /tmp/AmiSSL.lha || exit $?; \
+RUN curl -fsSL "https://github.com/jens-maus/amissl/releases/download/5.3/AmiSSL-5.3-SDK.lha" -o /tmp/AmiSSL.lha || exit $?; \
     lha -xfq2 AmiSSL.lha; \
     mv ./AmiSSL/Developer /opt/sdk/AmiSSL; \
     rm -rf /tmp/*;


### PR DESCRIPTION
Update the AmiSSL version in base image to use the current available version. So the security related dependency is up to date.